### PR TITLE
fix: replace organization with organizationId to solve multiple errors (iOS_Example project)

### DIFF
--- a/Examples/iOS_Example/iOS_Example/Chat/CreateChatCompletion.swift
+++ b/Examples/iOS_Example/iOS_Example/Chat/CreateChatCompletion.swift
@@ -64,7 +64,7 @@ struct CreateChatCompletionExample: View {
                         Task {
                             do {
                                 let config = Configuration(
-                                    organization: "INSERT-ORGANIZATION-ID",
+                                    organizationId: "INSERT-ORGANIZATION-ID",
                                     apiKey: "INSERT-API-KEY"
                                 )
                                 let openAI = OpenAI(config)

--- a/Examples/iOS_Example/iOS_Example/Completion/EditExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Completion/EditExample.swift
@@ -53,7 +53,7 @@ struct EditExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
                             let openAI = OpenAI(config)

--- a/Examples/iOS_Example/iOS_Example/Completion/GenerateCompletionExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Completion/GenerateCompletionExample.swift
@@ -52,7 +52,7 @@ struct GenerateCompletionExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
                             let openAI = OpenAI(config)

--- a/Examples/iOS_Example/iOS_Example/Image/EditImageExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Image/EditImageExample.swift
@@ -48,7 +48,7 @@ struct EditImageExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
                             let openAI = OpenAI(config)

--- a/Examples/iOS_Example/iOS_Example/Image/GenerateImageExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Image/GenerateImageExample.swift
@@ -44,7 +44,7 @@ struct GenerateImageExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
 

--- a/Examples/iOS_Example/iOS_Example/Image/GenerateImageVariationsExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Image/GenerateImageVariationsExample.swift
@@ -48,7 +48,7 @@ struct GenerateImageVariationExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
                             let openAI = OpenAI(config)

--- a/Examples/iOS_Example/iOS_Example/Model/ListModelsExample.swift
+++ b/Examples/iOS_Example/iOS_Example/Model/ListModelsExample.swift
@@ -47,7 +47,7 @@ struct ListModelsExample: View {
                     Task {
                         do {
                             let config = Configuration(
-                                organization: "INSERT-ORGANIZATION-ID",
+                                organizationId: "INSERT-ORGANIZATION-ID",
                                 apiKey: "INSERT-API-KEY"
                             )
                             let openAi = OpenAI(config)


### PR DESCRIPTION
The iOS example project is using the old Configuration initializer parameter name "organization". This leads to multiple error, if you try to start the example project.

This PR replaced "organization" with "organizationId" to fix the issues.
